### PR TITLE
add encryption and transport parameter to sip.pp

### DIFF
--- a/manifests/sip.pp
+++ b/manifests/sip.pp
@@ -25,12 +25,15 @@ define asterisk::sip (
   $t38pt_udptl   = false,
   $disallow      = [],
   $allow         = [],
-  $dtmfmode      = false
+  $dtmfmode      = false,
+  $transports    = [],
+  $encryption    = ''
 ) {
 
   # Ensure that we can iterate over some of the parameters.
   validate_array($disallow)
   validate_array($allow)
+  validate_array($transports)
 
   asterisk::dotd::file {"sip_${name}.conf":
     ensure   => $ensure,

--- a/templates/snippet/sip.erb
+++ b/templates/snippet/sip.erb
@@ -76,3 +76,9 @@ pickupgroup=<%= pickupgroup %>
 <% if dtmfmode != false -%>
 dtmfmode=<%= dtmfmode %>
 <% end -%>
+<% if ! transports.empty? -%>
+transport=<%= transports.join(',') %>
+<% end -%>
+<% if encryption != '' -%>
+encryption=<%= encryption %>
+<% end -%>


### PR DESCRIPTION
transport: specify array of protocols to use for signaling.
           Possible values are udp, tcp, tls

encryption: specify if you want to use srtp
