### PR TITLE
Fix templates syntax

### DIFF
--- a/templates/snippet/sip.erb
+++ b/templates/snippet/sip.erb
@@ -1,9 +1,6 @@
 ; THIS FILE IS MANAGED BY PUPPET
 ; all local modifications will be lost
-[<%= @name %>]
-<% if @template_name -%>
-(<%= @template_name %>)
-<% end -%>
+[<%= @name %>]<% if @template_name %>(<%= @template_name %>)<% end %>
 <% if @account_type -%>
 type=<%= @account_type %>
 <% end -%>


### PR DESCRIPTION
Fix warning
[Oct 25 16:37:55] WARNING[26130]: config.c:2018 process_text_line: No '=' (equal sign) in line 83 of /etc/asterisk/sip.d/user.conf